### PR TITLE
Move ExtractString definition to earlier point in ClientEx::Details namespace extension

### DIFF
--- a/DbgModelCppLib/DbgModelClientEx.h
+++ b/DbgModelCppLib/DbgModelClientEx.h
@@ -451,6 +451,42 @@ template<typename TDestSymbol> TDestSymbol symbol_cast(_In_ const Symbol& src);
 
 namespace Details
 {
+    //*************************************************
+    // String Extraction:
+    //
+
+    template<typename TArg> struct StringExtractorHelper;
+
+    template<>
+    struct StringExtractorHelper<wchar_t*>
+    {
+      static _Ret_z_ const wchar_t* GetString(_In_z_ const wchar_t* pc) { return pc; }
+    };
+
+    template<>
+    struct StringExtractorHelper<const wchar_t*>
+    {
+      static _Ret_z_ const wchar_t* GetString(_In_z_ const wchar_t* pc) { return pc; }
+    };
+
+    template<>
+    struct StringExtractorHelper<std::wstring>
+    {
+      static _Ret_z_ const wchar_t* GetString(_In_ const std::wstring& str) { return str.c_str(); }
+    };
+
+    // ExtractString():
+    //
+    // Extracts a const wchar_t * from the incoming argument.  This allows generic passing of anything we
+    // can pull a string from (e.g.: wchar_t *, std::wstring).
+    //
+    template<typename TArg>
+    _Ret_z_ const wchar_t* ExtractString(TArg&& str)
+    {
+      return StringExtractorHelper<std::decay_t<TArg>>::GetString(std::forward<TArg>(str));
+    }
+
+
     // SymbolChildrenRef:
     //
     // Returned from Children() (or another such method) to represent all (or a subset of) children of
@@ -3351,41 +3387,6 @@ namespace Details
         ComPtr<IModelIterator> m_spIterator;
         size_t m_pos;
     };
-
-    //*************************************************
-    // String Extraction:
-    //
-
-    template<typename TArg> struct StringExtractorHelper;
-
-    template<> 
-    struct StringExtractorHelper<wchar_t *>
-    {
-        static _Ret_z_ const wchar_t *GetString(_In_z_ const wchar_t *pc) { return pc; }
-    };
-
-    template<>
-    struct StringExtractorHelper<const wchar_t *>
-    {
-        static _Ret_z_ const wchar_t *GetString(_In_z_ const wchar_t *pc) { return pc; }
-    };
-
-    template<>
-    struct StringExtractorHelper<std::wstring>
-    {
-        static _Ret_z_ const wchar_t *GetString(_In_ const std::wstring &str) { return str.c_str(); }
-    };
-
-    // ExtractString():
-    //
-    // Extracts a const wchar_t * from the incoming argument.  This allows generic passing of anything we
-    // can pull a string from (e.g.: wchar_t *, std::wstring).
-    //
-    template<typename TArg>
-    _Ret_z_ const wchar_t *ExtractString(TArg&& str)
-    {
-        return StringExtractorHelper<std::decay_t<TArg>>::GetString(std::forward<TArg>(str));
-    }
 
     //*************************************************
     // Key Filling:


### PR DESCRIPTION
This PR addresses one of the build concerns raised in the following issues:
- [The CPP sample fails to compile with VS 2019 tools (142) #2](https://github.com/microsoft/WinDbg-Libraries/issues/2) 
- [Unable to build SimpleIntroClientLibrary (Cpp) #15](https://github.com/microsoft/WinDbg-Samples/issues/15) 

Specifically:

![image](https://user-images.githubusercontent.com/13523259/82735130-70b03600-9ced-11ea-9a5e-9e70df4e1f0e.png)

```
1><mypath>\WinDbg-Samples\DataModelHelloWorld\Cpp\packages\Microsoft.Debugging.DataModel.CppLib.1.0.0\build\native\include\DbgModelClientEx.h(1421,69): error C2039: 'ExtractString': is not a member of 'Debugger::DataModel::ClientEx::Details'
1><mypath>\WinDbg-Samples\DataModelHelloWorld\Cpp\packages\Microsoft.Debugging.DataModel.CppLib.1.0.0\build\native\include\DbgModelClientEx.h(452): message : see declaration of 'Debugger::DataModel::ClientEx::Details'
1><mypath>\WinDbg-Samples\DataModelHelloWorld\Cpp\packages\Microsoft.Debugging.DataModel.CppLib.1.0.0\build\native\include\DbgModelClientEx.h(1421,69): message : This diagnostic occurred in the compiler generated function 'Debugger::DataModel::ClientEx::Module::Module(const Debugger::DataModel::ClientEx::HostContext &,TStr &&)'
```

Hopefully this an ideal fix