### PR TITLE
Compile RegularUnpacker<TTuple, i, remaining>::UnpackInto without __DBGMODEL_TEST_H__ defined

### DIFF
--- a/DbgModelCppLib/DbgModelClientEx.h
+++ b/DbgModelCppLib/DbgModelClientEx.h
@@ -7823,6 +7823,8 @@ inline Object Object::ConstructInstance(Deconstruction& deconstruction)
     return Object(std::move(spInstance));
 }
 
+#endif // __DBGMODEL_TEST_H__
+
 namespace Details
 {
     template<typename TTuple, size_t i, size_t remaining>
@@ -7849,9 +7851,6 @@ namespace Details
         Unpacker<TTuple, i + 1, remaining - 1>::UnpackInto(packSize, ppArgumentPack, tuple);
     }
 }
-
-#endif // __DBGMODEL_TEST_H__
-
 } // ClientEx
 
 //**************************************************************************


### PR DESCRIPTION
Resolves #4.

**NOTE**: In order to compile at all with the v142 toolset, I needed to apply 56eaeec40d8f40cfb73f1384fba9cd9a0dc2ad9b from #2. Would be nice to get that pulled.
