### PR TITLE
Make SymChildrenRef::operator[](const wchar_t*) const

### DIFF
--- a/DbgModelCppLib/DbgModelClientEx.h
+++ b/DbgModelCppLib/DbgModelClientEx.h
@@ -566,7 +566,7 @@ namespace Details
         //
         // Returns a child symbol.
         //
-        TSymChild operator[](_In_z_ const wchar_t *childName)
+        TSymChild operator[](_In_z_ const wchar_t *childName) const
         {
             ComPtr<IDebugHostSymbolEnumerator> spEnum;
             CheckHr(m_sym->EnumerateChildren(m_enumKind, childName, &spEnum));


### PR DESCRIPTION
Resolves #6.

Enables `SymChildrenRef::operator[](const wchar_t*)` to be called from `SymChildrenRef::operator[](const std::wstring&) const`