### PR TITLE
Synchronize DbgModelClientEx.h with internal version:

### DIFF
--- a/DbgModelCppLib.nuspec
+++ b/DbgModelCppLib.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Microsoft.Debugging.DataModel.CppLib</id>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <description>A header-only C++ library for producing and consuming data from the debugger data model.</description>
     <authors>Microsoft</authors>
     <license type="expression">MIT</license>

--- a/DbgModelCppLib/DbgModelClientEx.h
+++ b/DbgModelCppLib/DbgModelClientEx.h
@@ -5830,7 +5830,6 @@ namespace Details
         //
         constexpr size_t extraArgumentCount = sizeof...(extraValues);
         constexpr size_t packIgnoreCount = extraArgumentCount + 1;          // + 1 == const Object& (instanceObject)
-        constexpr size_t signaturePackCount = sizeof...(TArgs);
         constexpr size_t minPackSize = PackMatchingSize_WithIgnore_v<packIgnoreCount, TArgs...>;
 
         //
@@ -5878,7 +5877,6 @@ namespace Details
         //
         constexpr size_t extraArgumentCount = 0;
         constexpr size_t packIgnoreCount = extraArgumentCount + 0;
-        constexpr size_t signaturePackCount = sizeof...(TArgs);
         constexpr size_t minPackSize = PackMatchingSize_WithIgnore_v<packIgnoreCount, TArgs...>;
 
         //

--- a/DbgModelCppLib/DbgModelClientEx.h
+++ b/DbgModelCppLib/DbgModelClientEx.h
@@ -447,7 +447,7 @@ TDestSymbol symbol_cast(_In_ IDebugHostSymbol *pSymbol)
         throw std::bad_cast();
     }
 
-    ComPtr<TDestSymbol::SymbolTypeInterface> spDerivedSymbolInterface;
+    ComPtr<typename TDestSymbol::SymbolTypeInterface> spDerivedSymbolInterface;
     CheckHr(pSymbol->QueryInterface(IID_PPV_ARGS(&spDerivedSymbolInterface)));
     return TDestSymbol(std::move(spDerivedSymbolInterface));
 }
@@ -3562,6 +3562,15 @@ namespace Details
         }
     };
 
+    template<typename T, typename... TArgs>
+    ParameterPack PackValuesHelper(TArgs&&... args)
+    {
+        size_t packSize = sizeof...(args);
+        ParameterPack argPack(new T[packSize]);
+        Packer<0, TArgs...>::PackInto(argPack, std::forward<TArgs>(args)...);
+        return argPack;
+    }
+
     // PackValues():
     //
     // Packs a set of arguments into an allocated array of objects and returns it.
@@ -3569,10 +3578,7 @@ namespace Details
     template<typename... TArgs>
     ParameterPack PackValues(TArgs&&... args)
     {
-        size_t packSize = sizeof...(args);
-        ParameterPack argPack(new Object[packSize]);
-        Packer<0, TArgs...>::PackInto(argPack, std::forward<TArgs>(args)...);
-        return argPack;
+        return PackValuesHelper<Object>(std::forward<TArgs>(args)...);
     }
 
     template<size_t i, size_t count, typename TTuple>


### PR DESCRIPTION
    - Updates to address some C++ compliance issues that generate warnings/errors with latest VS2022
    - Update .nuspec to 1.0.3 for updated push to NUGET