### PR TITLE
Fix new MSVC warning in DbgModelClientEx.h

### DIFF
--- a/DbgModelCppLib/DbgModelClientEx.h
+++ b/DbgModelCppLib/DbgModelClientEx.h
@@ -9447,7 +9447,7 @@ namespace Details
     template<typename TArg, typename... TArgs>
     struct ExtensionNameAcquisition<TArg, TArgs...>
     {
-        static void FillName(_Inout_ std::wstring& modelName, _In_ TArg record, _In_ const TArgs&... records)
+        static void FillName(_Inout_ std::wstring& modelName, _In_ TArg /*record*/, _In_ const TArgs&... records)
         {
             return ExtensionNameAcquisition<TArgs...>::FillName(modelName, records...);
         }


### PR DESCRIPTION
MSVC is getting smarter about spotting potential issues. In this case, an unused function parameter in a template function is flagged by the newest preview builds (verified with VS 2022 17.14 preview 2).

Fix: Comment-out the parameter name, as is done in other similar unused parameters throughout this file.